### PR TITLE
[fix] ensure we keep backpressure on the network

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,7 +23,7 @@ publisher.write({ foo: 'bar' });
 
 ## API
 
-### createReadStream(reader[, type])
+### createReadStream(reader[, type, opts])
 
   Create a readable stream from `reader`.
 
@@ -32,6 +32,13 @@ publisher.write({ foo: 'bar' });
   - `json`: `msg.json()` (default)
   - `buffer`: `msg.body`
   - `message`: `msg`
+
+  `opts` supports:
+
+  - `highWaterMark`: Selecting a `highWaterMark` of `0` will ensure no jobs
+  get buffered and marked as finished before the writeStream consuming the
+  messages accepts them. This keeps backpressure on nsqd side but will
+  negatively impact performance in high throughput cases.
 
 ### createWriteStream(writer, topic)
 
@@ -42,7 +49,8 @@ publisher.write({ foo: 'bar' });
 ## Backpressure
 
   Backpressure is created by not `.finish()`ing messages until they have
-  been consumed.
+  been consumed. *NOTE* Some messages will be buffered in memory and marked as
+  finished if `highWaterMark` is not set to 0.
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ publisher.write({ foo: 'bar' });
   get buffered and marked as finished before the writeStream consuming the
   messages accepts them. This keeps backpressure on nsqd side but will
   negatively impact performance in high throughput cases.
-  - `type`: Same as Type above.
+  - `type`: Fallback for the `type` argument
 
 ### createWriteStream(writer, topic)
 

--- a/Readme.md
+++ b/Readme.md
@@ -39,6 +39,7 @@ publisher.write({ foo: 'bar' });
   get buffered and marked as finished before the writeStream consuming the
   messages accepts them. This keeps backpressure on nsqd side but will
   negatively impact performance in high throughput cases.
+  - `type`: Same as Type above.
 
 ### createWriteStream(writer, topic)
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ exports.createReadStream = function(reader, type){
   }
 
   var objectMode = json || message;
-  var stream = Stream.Readable({ objectMode: objectMode });
+  var stream = Stream.Readable({ objectMode: objectMode, highWaterMark: 0 });
 
   stream._read = function(){
     next(function(msg){

--- a/index.js
+++ b/index.js
@@ -2,8 +2,15 @@ var Stream = require('readable-stream');
 var inherits = require('util').inherits;
 var assert = require('assert');
 
-exports.createReadStream = function(reader, type){
+exports.createReadStream = function(reader, type, opts){
   assert(reader, 'reader required');
+  if (typeof type !== 'string' && !opts) {
+    opts = type;
+    type = null;
+  }
+
+  opts = opts || {};
+  type = type || opts.type;
 
   var json = !type || 'json' == type;
   var buffer = 'buffer' == type;
@@ -22,7 +29,10 @@ exports.createReadStream = function(reader, type){
   }
 
   var objectMode = json || message;
-  var stream = Stream.Readable({ objectMode: objectMode, highWaterMark: 0 });
+  var stream = Stream.Readable({
+    objectMode: objectMode,
+    highWaterMark: options.highWaterMark
+  });
 
   stream._read = function(){
     next(function(msg){


### PR DESCRIPTION
This prevents us from buffering jobs in memory to keep the backpressure on the network so we don't get more jobs than we ask for from the configured `nsq.js` client.

Thoughts @juliangruber? I want to prevent _read from being called pre-emptively to accomplish the above. 